### PR TITLE
trimStr() variable naming consistency

### DIFF
--- a/Chapter23/createUnsorted.c
+++ b/Chapter23/createUnsorted.c
@@ -143,13 +143,13 @@ void putName( char* pStr , FILE* outFileDesc )  {
   // Returns:
   //   The length of the string after trimming.
   //
-int trimStr( char* pString )  {
+int trimStr( char* pStr )  {
   size_t first , last , lenIn , lenOut ;
   first = last = lenIn = lenOut = 0;
   
-  lenIn = strlen( pString );
+  lenIn = strlen( pStr );
   char tmpStr[ lenIn+1 ];      // Create working copy.
-  strcpy( tmpStr , pString );
+  strcpy( tmpStr , pStr );
   char* pTmp = tmpStr;         // pTmp may change in Left Trim segment.
   
     // Left Trim
@@ -170,7 +170,7 @@ int trimStr( char* pString )  {
   }
   lenOut = strlen( pTmp );     // Length of trimmed string.
   if( lenIn != lenOut )        // Did we change anything?
-    strcpy( pString , pTmp );  // Yes, copy trimmed string back.
+    strcpy( pStr , pTmp );     // Yes, copy trimmed string back.
   return lenOut;
 }
 

--- a/Chapter23/test_trimStr.c
+++ b/Chapter23/test_trimStr.c
@@ -87,10 +87,10 @@ int trimStrInPlace( char* pString )  {
   size_t first , last , lenIn , lenOut ;
   first = last = lenIn = lenOut = 0;
   
-  lenIn = strlen( pString );   //
-  char tmpStr[ lenIn+1 ];      // Create working copy.
-  strcpy( tmpStr , pString );  // 
-  char* pTmp = tmpStr;         // pTmp may change in Left Trim segment.
+  lenIn = strlen( pString );      //
+  char tmpString[ lenIn+1 ];      // Create working copy.
+  strcpy( tmpString , pString );  // 
+  char* pTmp = tmpString;         // pTmp may change in Left Trim segment.
   
     // Left Trim
     // Find 1st non-whitespace char; pStr will point to that.

--- a/Chapter23/test_trimStr.c
+++ b/Chapter23/test_trimStr.c
@@ -79,7 +79,7 @@ char* trimStr( char* pStr )  {
   //                  the original string in place. 
   //
   // Parameter:
-  //   pString - pointer of string to be trimmed/modified.
+  //   pStr - pointer of string to be trimmed/modified.
   // Returns:
   //   The length of the string after trimming.
   //

--- a/Chapter23/test_trimStr.c
+++ b/Chapter23/test_trimStr.c
@@ -21,9 +21,9 @@
 #include <string.h>
 
 
-char* trimStr(        char* pString );
-int   trimStrInPlace( char* pString );
-void  testTrim( int testNum , char* pString );
+char* trimStr(        char* pStr );
+int   trimStrInPlace( char* pStr );
+void  testTrim( int testNum , char* pStr );
 
 
 int main( void )  {
@@ -42,30 +42,30 @@ int main( void )  {
   //           modified; therefore, return value is essential.
   //
   // Parameter:
-  //   pString - pointer to string to be trimmed.
+  //   pStr - pointer to string to be trimmed.
   // Returns:
   //   A pointer to the beginning of the trimmed string.
   //
-char* trimStr( char* pString )  {
+char* trimStr( char* pStr )  {
   size_t first , last , len ;
   first = last = len = 0;
 
     // Left Trim
     // Find 1st non-whitespace char; pStr will point to that.
-  while( isspace( pString[ first ] ) )
+  while( isspace( pStr[ first ] ) )
     first++;
-  pString += first;
+  pStr += first;
 
-  len = strlen( pString ); // Get new length after Left Trim.
-  if( len )  {             // Check for empty string. e.g. "   " trimmed to nothing.
+  len = strlen( pStr ); // Get new length after Left Trim.
+  if( len )  {          // Check for empty string. e.g. "   " trimmed to nothing.
       // Right Trim
       // Find 1st non-whitespace char & set NUL character there.
     last = len-1; // off-by-1 adjustment.
-    while( isspace( pString[ last ] ) )
+    while( isspace( pStr[ last ] ) )
       last--;
-    pString[ last+1 ] = 0;  // Terminate trimmed string.
+    pStr[ last+1 ] = 0;  // Terminate trimmed string.
   }
-  return pString;
+  return pStr;
 }
 
 
@@ -83,14 +83,14 @@ char* trimStr( char* pString )  {
   // Returns:
   //   The length of the string after trimming.
   //
-int trimStrInPlace( char* pString )  {
+int trimStrInPlace( char* pStr )  {
   size_t first , last , lenIn , lenOut ;
   first = last = lenIn = lenOut = 0;
   
-  lenIn = strlen( pString );      //
-  char tmpString[ lenIn+1 ];      // Create working copy.
-  strcpy( tmpString , pString );  // 
-  char* pTmp = tmpString;         // pTmp may change in Left Trim segment.
+  lenIn = strlen( pStr );   //
+  char tmpStr[ lenIn+1 ];   // Create working copy.
+  strcpy( tmpStr , pStr );  // 
+  char* pTmp = tmpStr;      // pTmp may change in Left Trim segment.
   
     // Left Trim
     // Find 1st non-whitespace char; pStr will point to that.
@@ -108,26 +108,26 @@ int trimStrInPlace( char* pString )  {
       last--;
     pTmp[ last+1 ] = '\0';  // Terminate trimmed string.
   }
-  lenOut = strlen( pTmp );     // Length of trimmed string.
-  if( lenIn != lenOut )        // Did we change anything?
-    strcpy( pString , pTmp );  // Yes, copy trimmed string back.
+  lenOut = strlen( pTmp );  // Length of trimmed string.
+  if( lenIn != lenOut )     // Did we change anything?
+    strcpy( pStr , pTmp );  // Yes, copy trimmed string back.
   return lenOut;
 }
 
 
-void testTrim( int testNum , char* pString )  {
+void testTrim( int testNum , char* pStr )  {
   size_t len;
-  char testString[ strlen( pString ) + 1];
+  char testStr[ strlen( pStr ) + 1];
   char* pTest;
   
-  strcpy( testString , pString );
-  fprintf( stderr , "%1d. original: \"%s\" [len:%d]\n"   , testNum, testString , (int)strlen(pString) );
-  pTest = trimStr( testString );
+  strcpy( testStr , pStr );
+  fprintf( stderr , "%1d. original: \"%s\" [len:%d]\n"   , testNum, testStr , (int)strlen( pStr ) );
+  pTest = trimStr( testStr );
   fprintf( stderr , "    trimStr: \"%s\" [len:%d]\n" , pTest ,  (int)strlen( pTest ));
 
-  strcpy( testString , pString );
-  len = trimStrInPlace( testString );
-  fprintf( stderr , "   trimStr2: \"%s\" [len:%d]\n\n" , testString , (int)len ) ;
+  strcpy( testStr , pStr );
+  len = trimStrInPlace( testStr );
+  fprintf( stderr , "   trimStr2: \"%s\" [len:%d]\n\n" , testStr , (int)len ) ;
 }
 
   /* eof */

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ alt="https://www.packtpub.com/" border="5" /></a>
 
 * **Page 107:** In code listing for `convertDigitToInt.c`, the line `#include <stdio.h>` is missing before `int main( void )`. It should be the first line of the code listing.
 
-* **Page 109:** The program name `logicals.c` is incorrectly given as `logical.c` (missing plural 's').
+* **Page 109:** In the last paragraph before the code listing, the program name `logical.c` is missing a plural 's'. It should be `logicals.c`.
 
 * **Page 110:** The last `printf()` statement of the function `void printLogicalOR()` shows an incorrect parameter value. It should be
 
@@ -142,8 +142,8 @@ The correct Operator precedence table may be found on Page 660.
 * **Page 230:** The next to last paragraph should read
   > All the values of each array are initialized to 0 when the value given within `{` and `}` is 0, 
 as in `int a[5] = {0};` otherwise the values are assigned in the sequence given within `{` and `}`, 
-as in `int b[5] = { 5 , 4 , 3 , 2 , 1 }`. Only the values given will initialize the corresponding elements; so,
-  >  `int c[5] = { 5 , 4 };` only initialized the first two elements and the remaining elements are unintialized.
+as in `int b[5] = { 5 , 4 , 3 , 2 , 1 }`. Only values given will initialize the corresponding elements; so,
+  >  `int c[5] = { 5 , 4 };` initializes onlly the first two elements while the remaining elements are unintialized.
 
 * **Page 252:** The initialization shown for `array3D` is for a 3 x 2 x 5 array.<br>
 The initialization for a 3 x 4 x 5 array should appear as

--- a/README.md
+++ b/README.md
@@ -217,6 +217,39 @@ The initialization for a 3 x 4 x 5 array should appear as
             exit( EXIT_FAILURE );
           }
 
+* **Pages 544-545:** In the source code listing for `trimStr()`, there is inconsistent naming of the variables `pStr` (should not be `pString`) and `tmpStr` (should not be `tmpString`). The function `trimStr()` should thus appear as follows:
+
+        int trimStr( char* pStr )  {
+          size_t first , last , lenIn , lenOut ;
+          first = last = lenIn = lenOut = 0;
+  
+            lenIn = strlen( pStr );   //
+            char tmpStr[ lenIn+1 ];   // Create working copy.
+            strcpy( tmpStr , pStr );  // 
+            char* pTmp = tmpStr;      // pTmp may change in Left Trim segment.
+  
+              // Left Trim
+              // Find 1st non-whitespace char; pStr will point to that.
+            while( isspace( pTmp[ first ] ) )
+              first++;
+            pTmp += first;
+
+            lenOut = strlen( pTmp );     // Get new length after Left Trim.
+            if( lenOut )  {              // Check for empty string.
+                                         //  e.g. "   " trimmed to nothing.
+                // Right Trim
+                // Find 1st non-whitespace char & set NUL character there.
+              last = lenOut-1;           // off-by-1 adjustment.
+              while( isspace( pTmp[ last ] ) )
+                last--;
+              pTmp[ last+1 ] = '\0';  // Terminate trimmed string.
+            }
+            lenOut = strlen( pTmp );  // Length of trimmed string.
+            if( lenIn != lenOut )     // Did we change anything?
+              strcpy( pStr , pTmp );  // Yes, copy trimmed string back.
+            return lenOut;
+          }
+
 * **Page 547:** In the source code snippet to declare the `nameBuffer` array, the symbol `stringMax` is incorrect; it should be `kStringMax` as follows:
 
         char nameBuffer[ kStringMax ];


### PR DESCRIPTION
Use `xStr` suffix consistently instead of `xString` suffix for variables.